### PR TITLE
Plausible integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ LOCAL=1
 TWITTER_ACCOUNT=https://twitter.com/
 GITHUB_ACCOUNT=https://github.com/
 APP_NAME=Tars.Run
+PLAUSIBLE_ACCOUNT=
 #----------------------------------------
 #   CORS / DOMAINS
 #----------------------------------------

--- a/cmd/web/helpers.go
+++ b/cmd/web/helpers.go
@@ -83,6 +83,7 @@ func (app *application) addDefaultData(td *templateData, r *http.Request) *templ
 	td.Names.AppName = app.config.Names.AppName
 	td.Names.Twitter = app.config.Names.TwitterAccount
 	td.Names.Github = app.config.Names.GithubAccount
+	td.Names.Plausible = app.config.Names.PlausibleAccount
 	return td
 }
 

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -32,9 +32,10 @@ type templateData struct {
 }
 
 type userTemplateData struct {
-	AppName string
-	Github  string
-	Twitter string
+	AppName   string
+	Github    string
+	Twitter   string
+	Plausible string
 }
 
 func main() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,9 +26,10 @@ type dbConf struct {
 
 type names struct {
 	// Application Name
-	AppName        string `env:"APP_NAME,default=Tars.Run"`
-	TwitterAccount string `env:"TWITTER_ACCOUNT,default=#"`
-	GithubAccount  string `env:"GITHUB_ACCOUNT,default=#"`
+	AppName          string `env:"APP_NAME,default=Tars.Run"`
+	TwitterAccount   string `env:"TWITTER_ACCOUNT,default=#"`
+	GithubAccount    string `env:"GITHUB_ACCOUNT,default=#"`
+	PlausibleAccount string `env:"PLAUSIBLE_ACCOUNT,default="`
 }
 
 type serverConf struct {

--- a/ui/html/base.layout.tmpl
+++ b/ui/html/base.layout.tmpl
@@ -8,6 +8,9 @@
     <script src="/static/js/bundle.js" defer></script>
     <script src="/static/js/local-storage.js" defer></script>
     <link rel="icon" type="image/x-icon" href="/static/icons/favicon.ico">
+    {{ if .Names.Plausible }}
+      <script defer data-domain="{{ .Names.Plausible }}" src="https://plausible.io/js/plausible.js"></script>
+    {{ end }}
     <title>{{template "title" .}} - {{ .Names.AppName }}</title>
   </head>
   <body class="h-full">


### PR DESCRIPTION
Since the web app is seperated from the original next.js frontend, the [Plausible](https://plausible.io) analytics tool is no longer tracking any thing. 

This PR adds it to the base template. It is an optional extra and will only be available if an environment variabled named `PLAUSIBLE_ACCOUNT` is set. The account name must match the expected Plausible script tag.