### PR TITLE
Adjust style so original URL scrolls

### DIFF
--- a/assets/view/pages/home.templ
+++ b/assets/view/pages/home.templ
@@ -117,7 +117,7 @@ templ LinksSection() {
 		</div>
 		<div x-init="hashes = getLinks()">
 			<div class="mt-8 flex flex-col">
-				<div class="-mt-2 mb-5 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
+				<div class="-mt-2 mb-5 -mx-4 sm:-mx-6 lg:-mx-8">
 					<div class="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
 						<div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
 							<table class="min-w-full divide-y divide-gray-300">
@@ -153,7 +153,7 @@ templ LinksSection() {
 									<template x-for="hash in hashes.reverse()" :key="hash.hash">
 										<tr>
 											<td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
-												<span x-text="hash.long_url"></span>
+												<span class="block max-w-xl overflow-x-auto" x-text="hash.long_url"></span>
 											</td>
 											<td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
 												<a


### PR DESCRIPTION
I noticed that with the current style, the URL pushes the rest of the UI elements out of the visible area:

![image](https://github.com/user-attachments/assets/0f414bb0-0d40-4dc2-b617-abb0574de2bd)

By making the URL scroll, we can still see the rest of the elements on the page without scrolling:

![image](https://github.com/user-attachments/assets/8264e501-5a3e-41f4-9f33-1449df6aff57)
